### PR TITLE
Move `get_summary_raw`, `summary` and `get_over_time_data_10_mins` to…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-hole-api"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["Connor Holloway <c.holloway314@outlook.com>"]
 edition = "2018"
 license = "MIT"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@ use pi_hole_api::{PiHoleAPIConfig, UnauthenticatedPiHoleAPI};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api = PiHoleAPIConfig::new("http://192.168.0.19".to_string());
 
-    let status = api.get_summary();
-    println!("{:?}", status);
+    let version = api.get_version();
+    println!("{:?}", version);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,15 +72,6 @@ impl PiHoleAPIKey for PiHoleAPIConfigWithKey {
 }
 
 pub trait UnauthenticatedPiHoleAPI {
-    /// Get statistics in a raw format (no number format)
-    fn get_summary_raw(&self) -> Result<SummaryRaw, errors::APIError>;
-
-    /// Get statistics in a formatted style
-    fn get_summary(&self) -> Result<Summary, errors::APIError>;
-
-    /// Get statistics on the number of domains and ads for each 10 minute period
-    fn get_over_time_data_10_mins(&self) -> Result<OverTimeData, errors::APIError>;
-
     /// Get the Pi-Hole version.
     fn get_version(&self) -> Result<u32, errors::APIError>;
 
@@ -115,22 +106,6 @@ impl<T> UnauthenticatedPiHoleAPI for T
 where
     T: PiHoleAPIHost,
 {
-    fn get_summary_raw(&self) -> Result<SummaryRaw, errors::APIError> {
-        simple_json_request(self.get_host(), "/admin/api.php?summaryRaw", &NO_PARAMS)
-    }
-
-    fn get_summary(&self) -> Result<Summary, errors::APIError> {
-        simple_json_request(self.get_host(), "/admin/api.php?summary", &NO_PARAMS)
-    }
-
-    fn get_over_time_data_10_mins(&self) -> Result<OverTimeData, errors::APIError> {
-        simple_json_request(
-            self.get_host(),
-            "/admin/api.php?overTimeData10mins",
-            &NO_PARAMS,
-        )
-    }
-
     /// Get simple PiHole version
     fn get_version(&self) -> Result<u32, errors::APIError> {
         let raw_version: Version =
@@ -250,6 +225,15 @@ pub trait AuthenticatedPiHoleAPI {
 
     /// Get max logage
     fn get_max_logage(&self) -> Result<f32, errors::APIError>;
+
+    /// Get statistics in a raw format (no number format)
+    fn get_summary_raw(&self) -> Result<SummaryRaw, errors::APIError>;
+
+    /// Get statistics in a formatted style
+    fn get_summary(&self) -> Result<Summary, errors::APIError>;
+
+    /// Get statistics on the number of domains and ads for each 10 minute period
+    fn get_over_time_data_10_mins(&self) -> Result<OverTimeData, errors::APIError>;
 }
 
 fn authenticated_json_request<'a, T, I, K, V>(
@@ -580,5 +564,32 @@ where
             self.get_api_key(),
         )?;
         Ok(raw_data.remove("maxlogage").unwrap())
+    }
+
+    fn get_summary_raw(&self) -> Result<SummaryRaw, errors::APIError> {
+        authenticated_json_request(
+            self.get_host(),
+            "/admin/api.php",
+            [("summaryRaw", "")],
+            self.get_api_key(),
+        )
+    }
+
+    fn get_summary(&self) -> Result<Summary, errors::APIError> {
+        authenticated_json_request(
+            self.get_host(),
+            "/admin/api.php",
+            [("summary", "")],
+            self.get_api_key(),
+        )
+    }
+
+    fn get_over_time_data_10_mins(&self) -> Result<OverTimeData, errors::APIError> {
+        authenticated_json_request(
+            self.get_host(),
+            "/admin/api.php",
+            [("overTimeData10mins", "")],
+            self.get_api_key(),
+        )
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -80,7 +80,7 @@ impl TestContext for PiHoleTestContext {
 #[test]
 #[serial]
 fn get_summary_raw_test(ctx: &mut PiHoleTestContext) {
-    let summary_raw = ctx.unauthenticated_api.get_summary_raw().unwrap();
+    let summary_raw = ctx.authenticated_api.get_summary_raw().unwrap();
     assert!(
         summary_raw.status == "enabled" || summary_raw.status == "disabled",
         "Pi-Hole is neither enabled nor disabled"
@@ -91,7 +91,7 @@ fn get_summary_raw_test(ctx: &mut PiHoleTestContext) {
 #[test]
 #[serial]
 fn get_summary_test(ctx: &mut PiHoleTestContext) {
-    let summary = ctx.unauthenticated_api.get_summary().unwrap();
+    let summary = ctx.authenticated_api.get_summary().unwrap();
     assert!(
         summary.status == "enabled" || summary.status == "disabled",
         "Pi-Hole is neither enabled nor disabled"
@@ -103,9 +103,7 @@ fn get_summary_test(ctx: &mut PiHoleTestContext) {
 #[serial]
 fn get_over_time_data_10_mins_test(ctx: &mut PiHoleTestContext) {
     // Takes a while to update so performing a request will not immediately increase the counter
-    ctx.unauthenticated_api
-        .get_over_time_data_10_mins()
-        .unwrap();
+    ctx.authenticated_api.get_over_time_data_10_mins().unwrap();
 }
 
 #[test_context(PiHoleTestContext)]


### PR DESCRIPTION
… authenticated API